### PR TITLE
Storage get count

### DIFF
--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -73,7 +73,7 @@ class FileStorage:
         """get object based on class and id"""
         objs = self.all(cls)
         obj = cls + '.' + id
-        if objs[obj]:
+        if objs.get(obj):
             return objs[obj]
         else:
             return None

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -7,7 +7,6 @@ from datetime import datetime
 import inspect
 import models
 from models.engine import db_storage
-from models.engine import file_storage
 from models.amenity import Amenity
 from models.base_model import BaseModel
 from models.city import City

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import inspect
 import models
 from models.engine import db_storage
+from models.engine import file_storage
 from models.amenity import Amenity
 from models.base_model import BaseModel
 from models.city import City
@@ -21,6 +22,7 @@ import unittest
 DBStorage = db_storage.DBStorage
 classes = {"Amenity": Amenity, "City": City, "Place": Place,
            "Review": Review, "State": State, "User": User}
+storage = DBStorage()
 
 
 class TestDBStorageDocs(unittest.TestCase):
@@ -66,6 +68,43 @@ test_db_storage.py'])
                              "{:s} method needs a docstring".format(func[0]))
             self.assertTrue(len(func[1].__doc__) >= 1,
                             "{:s} method needs a docstring".format(func[0]))
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get(self):
+        """Test that get properly gets an objects based on class and id"""
+        storage.reload()
+        state = State(name="Arizona")
+        storage.new(state)
+        storage.save()
+        self.assertEqual(storage.get("State", state.id), state)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get_none(self):
+        """Test that get properly gets an objects based on class and id"""
+        storage.reload()
+        self.assertEqual(storage.get("State", "-1"), None)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count(self):
+        """Test that get properly gets an objects based on class and id"""
+        storage.reload()
+        original_count = storage.count("State")
+        state = State(name="Arizona")
+        storage.new(state)
+        storage.save()
+        self.assertEqual(storage.count("State"), original_count + 1)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count_none(self):
+        """Test that get properly gets an objects based on class and id"""
+        storage.reload()
+        original_count = storage.count()
+        original_state_count = storage.count("State")
+        state = State(name="Arizona")
+        storage.new(state)
+        storage.save()
+        self.assertEqual(storage.count("State"), original_state_count + 1)
+        self.assertEqual(storage.count(), original_count + 1)
 
 
 class TestFileStorage(unittest.TestCase):

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -113,3 +113,36 @@ class TestFileStorage(unittest.TestCase):
         with open("file.json", "r") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_get(self):
+        """Test that get properly gets an object based on class and id"""
+        storage = FileStorage()
+        state = State()
+        storage.new(state)
+        self.assertEqual(storage.get("State", state.id), state)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_get_none(self):
+        """Test that get properly returns None when object not found"""
+        storage = FileStorage()
+        self.assertEqual(storage.get("State", "-1"), None)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_count(self):
+        """Test that count properly returns count of objects based on class"""
+        storage = FileStorage()
+        original_count = len(storage.all("State"))
+        state = State()
+        storage.new(state)
+        self.assertEqual(storage.count("State"), original_count + 1)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_count_none(self):
+        """Test that count properly returns count of all objects if no class
+        given"""
+        storage = FileStorage()
+        original_count = len(storage.all())
+        state = State()
+        storage.new(state)
+        self.assertEqual(storage.count(), original_count + 1)


### PR DESCRIPTION
Hi! Could someone please approve this pull request? I added tests for the get and count method of both File Storage and DBStorage. I also updated the get method of FileStorage to use the Python dictionary get method so that it doesn't throw an error when a key doesn't exist.